### PR TITLE
Removed references to preprocessor definitions that were removed in SDL_mixer

### DIFF
--- a/src/SDL/Mixer.hs
+++ b/src/SDL/Mixer.hs
@@ -215,20 +215,16 @@ initialize flags = do
 data InitFlag
   = InitFLAC
   | InitMOD
-  | InitMODPlug
   | InitMP3
   | InitOGG
-  | InitFluidSynth
   deriving (Eq, Ord, Bounded, Read, Show)
 
 initToCInt :: InitFlag -> CInt
 initToCInt = \case
   InitFLAC       -> SDL.Raw.Mixer.INIT_FLAC
   InitMOD        -> SDL.Raw.Mixer.INIT_MOD
-  InitMODPlug    -> SDL.Raw.Mixer.INIT_MODPLUG
   InitMP3        -> SDL.Raw.Mixer.INIT_MP3
   InitOGG        -> SDL.Raw.Mixer.INIT_OGG
-  InitFluidSynth -> SDL.Raw.Mixer.INIT_FLUIDSYNTH
 
 -- | Cleans up any loaded libraries, freeing memory.
 quit :: MonadIO m => m ()
@@ -978,9 +974,7 @@ data MusicType
   | MID
   | OGG
   | MP3
-  | MP3_MAD
   | FLAC
-  | MODPlug
   deriving (Eq, Show, Read, Ord, Bounded)
 
 wordToMusicType :: SDL.Raw.Mixer.MusicType -> Maybe MusicType
@@ -992,9 +986,7 @@ wordToMusicType = \case
   SDL.Raw.Mixer.MUS_MID     -> Just MID
   SDL.Raw.Mixer.MUS_OGG     -> Just OGG
   SDL.Raw.Mixer.MUS_MP3     -> Just MP3
-  SDL.Raw.Mixer.MUS_MP3_MAD -> Just MP3_MAD
   SDL.Raw.Mixer.MUS_FLAC    -> Just FLAC
-  SDL.Raw.Mixer.MUS_MODPLUG -> Just MODPlug
   _                         -> Nothing
 
 -- | Gets the 'MusicType' of a given 'Music'.

--- a/src/SDL/Raw/Mixer.hsc
+++ b/src/SDL/Raw/Mixer.hsc
@@ -28,10 +28,8 @@ module SDL.Raw.Mixer
   , init
   , pattern INIT_FLAC
   , pattern INIT_MOD
-  , pattern INIT_MODPLUG
   , pattern INIT_MP3
   , pattern INIT_OGG
-  , pattern INIT_FLUIDSYNTH
   , quit
   , Format
   , pattern DEFAULT_FORMAT
@@ -131,9 +129,7 @@ module SDL.Raw.Mixer
   , pattern MUS_MID
   , pattern MUS_OGG
   , pattern MUS_MP3
-  , pattern MUS_MP3_MAD
   , pattern MUS_FLAC
-  , pattern MUS_MODPLUG
   , playingMusic
   , pausedMusic
   , fadingMusic
@@ -193,10 +189,8 @@ liftF "init" "Mix_Init"
 
 pattern INIT_FLAC       = (#const MIX_INIT_FLAC)
 pattern INIT_MOD        = (#const MIX_INIT_MOD)
-pattern INIT_MODPLUG    = (#const MIX_INIT_MODPLUG)
 pattern INIT_MP3        = (#const MIX_INIT_MP3)
 pattern INIT_OGG        = (#const MIX_INIT_OGG)
-pattern INIT_FLUIDSYNTH = (#const MIX_INIT_FLUIDSYNTH)
 
 liftF "quit" "Mix_Quit"
   [t|IO ()|]
@@ -401,9 +395,7 @@ pattern MUS_MOD     = (#const MUS_MOD)
 pattern MUS_MID     = (#const MUS_MID)
 pattern MUS_OGG     = (#const MUS_OGG)
 pattern MUS_MP3     = (#const MUS_MP3)
-pattern MUS_MP3_MAD = (#const MUS_MP3_MAD)
 pattern MUS_FLAC    = (#const MUS_FLAC)
-pattern MUS_MODPLUG = (#const MUS_MODPLUG)
 
 liftF "freeMusic" "Mix_FreeMusic"
   [t|Ptr Music -> IO ()|]


### PR DESCRIPTION
The wrapped library, SDL_mixer, [recently removed references](http://hg.libsdl.org/SDL_mixer/diff/92882ef2ab81/SDL_mixer.h) to `INIT_MODPLUG`, `INIT_FLUIDSYNTH`, `MUS_MP3_MAD`, and `MUS_MODPLUG`. The latter two were replaced with `MUS_MP3_MAD_UNUSED` and `MUS_MODPLUG_UNUSED` which are, fittingly, absent from the rest of the code.

This made it impossible for me to build the Haskell package while the latest version of SDL_mixer was on my Mac system (the only version I could get from Homebrew). See [this report](https://github.com/kivy/kivy/issues/5457) from a different project that also uses SDL_mixer and had the same trouble.

I made the changes in this pull request to a local version of the package, and I was able to build it and use it without a problem. Therefore, I thought it might be the right thing to do for the real version of the package too.